### PR TITLE
Refactor rating state

### DIFF
--- a/config/ratingState.js
+++ b/config/ratingState.js
@@ -1,0 +1,18 @@
+// global module to keep track of ratings most recently selected by user.
+
+module.exports = {
+	'a1_injection': 0,
+	'a2_broken_auth': 0,
+	'a3_sensitive_data': 0,
+	'a4_xxe': 0,
+	'a5_broken_access_control': 0,
+	'a6_sec_misconf': 0,
+	'a7_xss': 0,
+	'a8_ides': 0,
+	'a9_vuln_component': 0,
+	'a10_logging': 0,
+	'ax_csrf': 0,
+	'ax_redirect': 0,
+	'register': 0,
+	'forgotpw': 0,
+}

--- a/core/appHandler.js
+++ b/core/appHandler.js
@@ -5,6 +5,7 @@ var mathjs = require('mathjs')
 var libxmljs = require("libxmljs");
 var serialize = require("node-serialize")
 const Op = db.Sequelize.Op
+var ratingState = require('../config/ratingState')
 
 module.exports.userSearch = function (req, res) {
 	var query = "SELECT name,id FROM Users WHERE login='" + req.body.login + "'";
@@ -224,7 +225,8 @@ function listUsersAPIRating1(res) {
 }
 
 module.exports.listUsersAPI = function (req, res) {
-	var securityRating = req.params.securityRating ? req.params.securityRating : 0;
+	var vulnKey = 'a3_sensitive_data';
+	var securityRating = ratingState[vulnKey];
 	if (securityRating == 0 ){
 		listUsersAPIRating0(res);
 	} else if (securityRating == 1) {

--- a/routes/app.js
+++ b/routes/app.js
@@ -39,7 +39,7 @@ module.exports = function () {
         })
     })
 
-    router.get('/admin/usersapi/:securityRating', authHandler.isAuthenticated, appHandler.listUsersAPI)
+    router.get('/admin/usersapi', authHandler.isAuthenticated, appHandler.listUsersAPI)
 
     router.get('/admin/users', authHandler.isAuthenticated, function(req, res){
         res.render('app/adminusers')

--- a/routes/main.js
+++ b/routes/main.js
@@ -2,6 +2,7 @@ var router = require('express').Router()
 var vulnDict = require('../config/vulns')
 var ratingsDict = require('../config/ratings')
 var authHandler = require('../core/authHandler')
+var ratingState = require('../config/ratingState')
 
 module.exports = function (passport) {
 	router.get('/', authHandler.isAuthenticated, function (req, res) {
@@ -14,6 +15,7 @@ module.exports = function (passport) {
 
 	router.get('/learn/vulnerability/:vuln', authHandler.isAuthenticated, function (req, res) {
 		var query_rating = req.query.securityRating ? req.query.securityRating : 0;
+		ratingState[req.params.vuln] = query_rating
 		res.render('vulnerabilities/layout', {
 			vuln: req.params.vuln,
 			vuln_title: vulnDict[req.params.vuln],

--- a/routes/main.js
+++ b/routes/main.js
@@ -14,7 +14,7 @@ module.exports = function (passport) {
 	})
 
 	router.get('/learn/vulnerability/:vuln', authHandler.isAuthenticated, function (req, res) {
-		var query_rating = req.query.securityRating ? req.query.securityRating : 0;
+		var query_rating = req.query.securityRating ? req.query.securityRating : ratingState[req.params.vuln];
 		ratingState[req.params.vuln] = query_rating
 		res.render('vulnerabilities/layout', {
 			vuln: req.params.vuln,

--- a/views/app/adminusers.ejs
+++ b/views/app/adminusers.ejs
@@ -63,9 +63,7 @@
                    }
                 }
             };
-            var urlParams = new URLSearchParams(window.location.search);
-            var securityRating = urlParams.get('securityRating') 
-            xmlhttp.open("GET", "/app/admin/usersapi/" + securityRating, true);
+            xmlhttp.open("GET", "/app/admin/usersapi", true);
             xmlhttp.send();
         }
         loadUsers();

--- a/views/common/ratingChooser.ejs
+++ b/views/common/ratingChooser.ejs
@@ -17,11 +17,11 @@
     // get security level from query params
     document.addEventListener('DOMContentLoaded', (event) => {
         var params = new URLSearchParams(window.location.search);
-        var securityRating = 0
+        var securityRating = 0;
         if (params.get("securityRating") && params.get("securityRating")==1){
             securityRating = 1;
         };
         checked_input = document.getElementById("rating" + securityRating);
-        checked_input.setAttribute("checked", '')
+        checked_input.setAttribute("checked", '');
     });
 </script>

--- a/views/vulnerabilities/a3_sensitive_data/scenario.ejs
+++ b/views/vulnerabilities/a3_sensitive_data/scenario.ejs
@@ -1,7 +1,7 @@
 <div>
     <ul>
         <li>
-            <a href=<%='/app/admin/users?securityRating=' + securityRating %> > Admin: List Users</a>
+            <a href=<%='/app/admin/users'%> > Admin: List Users</a>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
This PR creates a module `ratingState` that keeps track of the most recently selected securityRating. Because .js modules are cached, they maintain state. Any route on the backend need only `require ratingState` to get and set the ratingState object. The module is simply an object that maps the vulnerabilities (represented by strings as defined in `ratings` and `vulns`) to integers (representing the security ratings). 

With the new `ratingState` module, I was able to eliminate the need to pass the selected securityRating as an additional parameter from the `app/:vuln` entrypoint to the vulnerable endpoints of A3. This is illustrated by screenshot below of the hardened version of the app. Previously, the hardened version (securityRating = 1) would have to be accessed at `app/admin/users/1` and the non-hardened version at
`app/admin/users/0`. Now, `app/:vuln` saves the user's selection to`ratingState`, then `app/admin/users` accesses the user's selection from `ratingState`.  Thus, the selection is updated once per route handling via `app/:vuln` and there is no need to pass the user's selection through the different downstream routes.

This did not appear to break the A2 hardening, but I did not test it thoroughly. The intention of the PR is to give us the option going forward of using the `ratingState` module to manage the security level selections.

![image](https://user-images.githubusercontent.com/12928553/126093286-59e36b5c-74c9-4ae4-872c-cb9ed6425dc8.png)
