### PR TITLE
A5   ba2

### DIFF
--- a/routes/app.js
+++ b/routes/app.js
@@ -80,7 +80,7 @@ module.exports = function () {
             vuln: 'a5_broken_access_control'
         })
     })
-
+   
     router.get('/redirect', appHandler.redirect)
 
     router.post('/usersearch', authHandler.isAuthenticated, appHandler.userSearch)
@@ -92,6 +92,14 @@ module.exports = function () {
     router.post('/modifyproduct', authHandler.isAuthenticated, appHandler.modifyProductSubmit)
 
     router.post('/useredit', authHandler.isAuthenticated, appHandler.userEditSubmit)
+
+    router.get('/useredit/toggle', authHandler.isAuthenticated, function (req, res) {
+        if(ratingState[req.query.vuln] == 1)
+            ratingState[req.query.vuln] = 0
+        else
+            ratingState[req.query.vuln] = 1
+        res.redirect('/app/useredit/')
+    })
 
     router.post('/calc', authHandler.isAuthenticated, appHandler.calc)
 

--- a/views/app/useredit.ejs
+++ b/views/app/useredit.ejs
@@ -9,14 +9,27 @@
 
     <div class='row'>
         <div class='col-md-6 col-md-offset-3'>
-            <h2> User Profile </h2>
+            <h2> User Profile </h2><br>
+            <h4><b>A2 Security Rating  <%= a2securityRating %></b><a href='/app/useredit/toggle?vuln=<%=vuln2%>'>(Toggle A2 Rating)</a><br>
+            <% if(a2securityRating == 0){%> No input validation performed<%}
+            else {%> Input validation performed<%}%>
+            </h4>
+
+
+            <br>
+
+            <h4><b>A5 Security Rating  <%= a5securityRating %></b> <a href='/app/useredit/toggle?vuln=<%=vuln5%>'>(Toggle A5 Rating)</a><br>
+                <% if(a5securityRating == 0){%> No user id verification performed at backend<%}
+                else {%> User id verification performed at backend <%}%>            
+            </h4>
+
 
             <% if (messages.success) { %>
                 <div class="alert alert-success"><%=messages.success%></div>
             <% } else if (messages.danger) { %>
                 <div class="alert alert-danger"><%= messages.danger %></div>
             <% } else if (messages.warning) {%>
-                <div class="alert alert-warning"><%= messages.warning %></div>
+                <div class="alert alert-warning"><%- messages.warning %></div>
             <% } else if (messages.info) {%>
                 <div class="alert alert-info"><%= messages.info %></div>
             <% } %>


### PR DESCRIPTION
A5 - Broken Authentication - Missing Authorization check in Edit User 

Edit User page (frontend) allows user to toggle between security ratings for OWASP Top 10 A2 (Broken Authentication) and A5(Broken Access).  Security Rating 0 remains original DVNA app.  Security Rating 1 is hardened version.

A5 - The primary focus of these commits.  At Security Rating 1, backend checks that id (via req.body.id) sent over from the front end to change a user's information matches the id (via req.user.id) of the actual user making the request.  This prevents users from changing other user's information, simply by changing id at the front-end using chrome inspector (or similar feature from other browsers)

A2 - Since no input verification was done on this page, I added the ability to do input verification here at Security Rating 1, in line OWASP hardening of A2 - Broken Authentication.  Basically, email (that it's a valid email address) and pw (that it's long and complex) inputs are now checked at backend at Security Rating 1.

Aside from A2, I do not think that it interferes with any to other currently implemented Vulnerability (A1, A3), however, please let me know if it does.

